### PR TITLE
Fix string overread warning with gcc-12.

### DIFF
--- a/tensorflow/lite/micro/micro_allocation_info.cc
+++ b/tensorflow/lite/micro/micro_allocation_info.cc
@@ -330,7 +330,7 @@ TfLiteStatus AllocationInfoBuilder::GetOfflinePlannedOffsets(
       auto metadata = model_->metadata()->Get(i);
 
       if (metadata->name()) {
-        const size_t metadata_name_size = strlen(metadata->name()->c_str());
+        const size_t metadata_name_size = metadata->name()->size();
 
         if ((strncmp(metadata->name()->c_str(), kOfflineMemAllocMetadata,
                      std::min(metadata_name_size,


### PR DESCRIPTION
Manually tested with gcc-12 that the build fails without this fix and passes with the fix.

BUG=http://b/258039184 and #1337